### PR TITLE
fix: harden planet file download in entrypoint against redirects and bad responses

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -115,7 +115,23 @@ fi
 
 if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
   log_params "Downloading Custom Planet File from Controller URL:" "$ZT_PLANET_URL_FILE"
-  sudo curl -s "$ZT_PLANET_URL_FILE" -o /var/lib/zerotier-one/planet
+  tmpfile=$(mktemp)
+  if sudo curl -sL -f --max-time 15 "$ZT_PLANET_URL_FILE" -o "$tmpfile" && [ -s "$tmpfile" ]; then
+    # Basic sanity check: a valid ZeroTier planet file should be at least a few hundred bytes
+    # (real planet files are typically 500+ bytes; reject anything suspiciously small,
+    # which usually indicates an HTML error page or empty/truncated response)
+    filesize=$(wc -c < "$tmpfile")
+    if [ "$filesize" -ge 500 ]; then
+      sudo cp "$tmpfile" /var/lib/zerotier-one/planet
+      sudo chmod 0644 /var/lib/zerotier-one/planet
+      log_params "Planet file updated successfully, size:" "$filesize bytes"
+    else
+      log_params "WARNING: Downloaded planet file looks invalid (too small), keeping existing file. Size:" "$filesize bytes"
+    fi
+  else
+    log "WARNING: Planet file download failed (curl error or empty response), keeping existing file"
+  fi
+  sudo rm -f -- "$tmpfile"
 fi
 
 if [ "x$@" != "x" ] && [ "x$ZT_DEVICEMAP" != "x" ]; then


### PR DESCRIPTION
## Summary
- `entrypoint.sh` now follows HTTP redirects (`-L`) and fails on HTTP error responses (`-f`) when downloading a custom planet file via `ZT_PLANET_URL_FILE`, instead of silently saving a redirect/error page body as if it were the planet file
- Download is capped at 15s (`--max-time`) so a hung endpoint can't stall container startup
- The file is downloaded to a temp file first, validated (non-empty and >= 500 bytes), and only then copied over the live planet file — a failed/invalid download now falls back to keeping the existing file with a warning instead of corrupting it

## Test plan
- [x] Verify CI checks pass on this PR
- [x] Confirm `entrypoint.sh` still passes `sh -n` syntax check
- [x] Manually exercise the redirect / HTTP-error / oversized-timeout paths if feasible

🤖 Generated with [Claude Code](https://claude.com/claude-code)