### PR TITLE
fix: lower minimum valid planet file size threshold to 100 bytes

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -118,10 +118,10 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
   tmpfile=$(mktemp)
   if sudo curl -sL -f --max-time 15 "$ZT_PLANET_URL_FILE" -o "$tmpfile" && [ -s "$tmpfile" ]; then
     # Basic sanity check: a valid ZeroTier planet file should be at least a few hundred bytes
-    # (real planet files are typically 500+ bytes; reject anything suspiciously small,
+    # (real planet files are typically 100+ bytes; reject anything suspiciously small,
     # which usually indicates an HTML error page or empty/truncated response)
     filesize=$(wc -c < "$tmpfile")
-    if [ "$filesize" -ge 500 ]; then
+    if [ "$filesize" -ge 100 ]; then
       sudo cp "$tmpfile" /var/lib/zerotier-one/planet
       sudo chmod 0644 /var/lib/zerotier-one/planet
       log_params "Planet file updated successfully, size:" "$filesize bytes"


### PR DESCRIPTION
## Summary
- Lowered the minimum accepted size for a downloaded ZeroTier planet file from 500 to 100 bytes, updating the comment to match
- Prevents valid (but smaller) planet file responses from being incorrectly rejected during entrypoint download validation

## Test plan
- [x] Verify CI checks pass on this PR
- [x] Confirm entrypoint still rejects genuinely invalid/small responses (e.g. HTML error pages) while accepting valid planet files

🤖 Generated with [Claude Code](https://claude.com/claude-code)