### PR TITLE
fix: force IPv4 for planet file download in entrypoint.sh

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -120,7 +120,7 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
   max_attempts=5
   success=false
   while [ "$attempt" -le "$max_attempts" ]; do
-    if sudo curl -sL -f --max-time 15 "$ZT_PLANET_URL_FILE" -o "$tmpfile" && [ -s "$tmpfile" ]; then
+    if sudo curl -sL -f -4 --max-time 15 "$ZT_PLANET_URL_FILE" -o "$tmpfile" && [ -s "$tmpfile" ]; then
       success=true
       break
     fi


### PR DESCRIPTION
## Summary
- Added `-4` to the `curl` call downloading the custom planet file so it always uses IPv4, regardless of what the container's DNS resolver prefers or exposes
- Some deployment environments' resolvers return only an IPv6 address for the planet file host (via `getent hosts`), and IPv6 connectivity to that endpoint has proven intermittently unreliable; IPv4 has been consistently reliable in testing

## Test plan
- [x] Verify CI checks pass on this PR
- [x] Confirm planet file download still succeeds in normal (dual-stack) environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)