### PR TITLE
fix: increase retry resilience for planet file download

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -117,16 +117,16 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
   log_params "Downloading Custom Planet File from Controller URL:" "$ZT_PLANET_URL_FILE"
   tmpfile=$(mktemp)
   attempt=1
-  max_attempts=5
+  max_attempts=10
   success=false
   while [ "$attempt" -le "$max_attempts" ]; do
-    if sudo curl -sL -f -4 --max-time 15 "$ZT_PLANET_URL_FILE" -o "$tmpfile" && [ -s "$tmpfile" ]; then
+    if sudo curl -sL -f -4 --max-time 30 "$ZT_PLANET_URL_FILE" -o "$tmpfile" && [ -s "$tmpfile" ]; then
       success=true
       break
     fi
     log_params "Planet file download attempt failed, retrying:" "attempt $attempt/$max_attempts"
     attempt=$((attempt + 1))
-    sleep 2
+    sleep 3
   done
   if [ "$success" = "true" ]; then
     # Basic sanity check: a valid ZeroTier planet file should be at least a few hundred bytes


### PR DESCRIPTION
## Summary
- Increased retry resilience for the custom planet file download in `entrypoint.sh`: `max_attempts` 5→10, `curl --max-time` 15→30, inter-attempt delay 2s→3s
- Real-world testing showed same-datacenter network paths to the planet file endpoint are more prone to intermittent server-side response aborts than external/internet-routed paths, and this longer, more generous retry sequence reliably succeeds where the shorter one does not (~5.5 minutes total retry budget in the worst case)

## Test plan
- [x] Verify CI checks pass on this PR
- [x] Confirm planet file download still succeeds promptly in normal (non-degraded) environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)