### PR TITLE
fix: reduce retry burst rate for planet file download

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -117,7 +117,7 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
   log_params "Downloading Custom Planet File from Controller URL:" "$ZT_PLANET_URL_FILE"
   tmpfile=$(mktemp)
   attempt=1
-  max_attempts=10
+  max_attempts=4
   success=false
   while [ "$attempt" -le "$max_attempts" ]; do
     if sudo curl -sL -f -4 --max-time 30 "$ZT_PLANET_URL_FILE" -o "$tmpfile" && [ -s "$tmpfile" ]; then
@@ -126,7 +126,7 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
     fi
     log_params "Planet file download attempt failed, retrying:" "attempt $attempt/$max_attempts"
     attempt=$((attempt + 1))
-    sleep 3
+    sleep 20
   done
   if [ "$success" = "true" ]; then
     # Basic sanity check: a valid ZeroTier planet file should be at least a few hundred bytes


### PR DESCRIPTION
## Summary
- Reduced retry burst rate for the custom planet file download in `entrypoint.sh`: `max_attempts` 10→4, inter-attempt delay 3s→20s
- Real-world testing showed rapid, closely-spaced retries (10 attempts, 3s apart) consistently fail with near-instant "connection aborted" errors, while an isolated request immediately afterward succeeds cleanly — suggesting server/platform-side rate-limiting or burst-detection that penalizes rapid repeated requests from the same source
- Spreading 4 attempts across up to 60s gives any such condition time to clear between tries instead of hammering the endpoint in a tight loop

## Test plan
- [x] Verify CI checks pass on this PR
- [x] Confirm planet file download still succeeds promptly in normal (non-degraded) environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)