### PR TITLE
fix: use curl --resolve for planet file download; bump docker/scout-action

### DIFF
--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Docker Scout
         id: docker-scout
         if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/scout-action@ce97ec1bb85613e8eb35d086fad0c77a6cedf983 # v1.23.0
+        uses: docker/scout-action@2688993af7bafd6ba8c6a74ec652442be91dd82b # v1.23.1
         with:
           command: cves,recommendations,compare
           image: ${{ steps.meta.outputs.tags }}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -119,8 +119,31 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
   attempt=1
   max_attempts=4
   success=false
+
+  # Extract hostname and port from the URL for use with --resolve
+  zt_planet_host=$(echo "$ZT_PLANET_URL_FILE" | sed -E 's#^[a-zA-Z]+://([^:/]+).*#\1#')
+  zt_planet_port=$(echo "$ZT_PLANET_URL_FILE" | sed -nE 's#^[a-zA-Z]+://[^:/]+:([0-9]+).*#\1#p')
+  if [ -z "$zt_planet_port" ]; then
+    case "$ZT_PLANET_URL_FILE" in
+      http://*) zt_planet_port=80 ;;
+      *) zt_planet_port=443 ;;
+    esac
+  fi
+
+  # Resolve to an IPv4 address specifically, to avoid unreliable IPv6 paths
+  # (some Docker DNS resolvers only return an AAAA record, and -4 alone does
+  # not reliably prevent curl from taking that IPv6 path)
+  zt_planet_ipv4=$(getent ahostsv4 "$zt_planet_host" 2>/dev/null | head -1 | awk '{print $1}')
+
+  if [ -n "$zt_planet_ipv4" ]; then
+    resolve_opts="--resolve ${zt_planet_host}:${zt_planet_port}:${zt_planet_ipv4}"
+  else
+    log_params "WARNING: Could not resolve an IPv4 address for" "$zt_planet_host, falling back to default resolution"
+    resolve_opts="-4"
+  fi
+
   while [ "$attempt" -le "$max_attempts" ]; do
-    if sudo curl -sL -f -4 --max-time 30 "$ZT_PLANET_URL_FILE" -o "$tmpfile" && [ -s "$tmpfile" ]; then
+    if sudo curl -sL -f $resolve_opts --max-time 30 "$ZT_PLANET_URL_FILE" -o "$tmpfile" && [ -s "$tmpfile" ]; then
       success=true
       break
     fi


### PR DESCRIPTION
## Summary
- Replace `-4` with `curl --resolve` for the planet file download in `scripts/entrypoint.sh`, resolving the target hostname to an IPv4 address via `getent ahostsv4` at runtime (falls back to `-4` if no IPv4 address can be resolved). Fixes intermittent "context canceled" failures seen when Docker's embedded DNS resolver only returns an AAAA record for the host.
- Bump `docker/scout-action` from 1.23.0 to 1.23.1 (dependabot, already merged into `dev`).

## Test plan
- [x] Verify CI checks pass on this PR
- [x] Confirm planet file download succeeds in a container where DNS only returns an AAAA record

🤖 Generated with [Claude Code](https://claude.com/claude-code)