### PR TITLE
debug: log resolved IPv4 address for planet file download

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -134,6 +134,7 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
   # (some Docker DNS resolvers only return an AAAA record, and -4 alone does
   # not reliably prevent curl from taking that IPv6 path)
   zt_planet_ipv4=$(getent ahostsv4 "$zt_planet_host" 2>/dev/null | head -1 | awk '{print $1}')
+  log_params "DEBUG - resolved IPv4:" "[$zt_planet_ipv4]"
 
   if [ -n "$zt_planet_ipv4" ]; then
     resolve_opts="--resolve ${zt_planet_host}:${zt_planet_port}:${zt_planet_ipv4}"


### PR DESCRIPTION
## Summary
- Add a temporary debug log line right after the `getent ahostsv4` call in `scripts/entrypoint.sh` to print the resolved IPv4 address, for verifying the `--resolve`-based planet file download fix in the field.

## Test plan
- [x] Verify CI checks pass on this PR
- [x] Confirm the debug log line prints the expected resolved IPv4 address at container startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)