### PR TITLE
debug: verbose curl errors, explicit exit codes, and no-sudo comparison run

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -144,7 +144,18 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
   fi
 
   while [ "$attempt" -le "$max_attempts" ]; do
-    if sudo curl -sL -f $resolve_opts --max-time 30 "$ZT_PLANET_URL_FILE" -o "$tmpfile" && [ -s "$tmpfile" ]; then
+    # DEBUG - comparison run without sudo, to isolate whether sudo itself is
+    # the boot-time culprit. Output/exit code only, not used for success logic.
+    nosudo_tmpfile=$(mktemp)
+    curl -L -f $resolve_opts --max-time 30 "$ZT_PLANET_URL_FILE" -o "$nosudo_tmpfile" 2>&1
+    curl_nosudo_exit=$?
+    log_params "DEBUG - non-sudo curl exit code:" "$curl_nosudo_exit"
+    rm -f -- "$nosudo_tmpfile"
+
+    sudo curl -L -f $resolve_opts --max-time 30 "$ZT_PLANET_URL_FILE" -o "$tmpfile" 2>&1
+    curl_exit=$?
+    log_params "DEBUG - curl exit code:" "$curl_exit"
+    if [ "$curl_exit" -eq 0 ] && [ -s "$tmpfile" ]; then
       success=true
       break
     fi


### PR DESCRIPTION
## Summary
- Temporary diagnostic change to the planet file download in `scripts/entrypoint.sh`: drop `-s` from the real `sudo curl` call so error output is visible instead of suppressed, capture and log the curl exit code explicitly instead of relying on it implicitly inside the `if`.
- Add a comparison `curl` run without `sudo` on each retry attempt (separate temp file, discarded immediately) to help isolate whether `sudo` itself is a factor in the intermittent boot-time failures. Output/exit code only, does not affect the retry/success logic.

## Test plan
- [x] Verify CI checks pass on this PR
- [x] Confirm both curl exit codes (sudo and non-sudo) are logged during a failing boot sequence, to compare behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)