### PR TITLE
fix: create planet file tmpfile as root to fix sudo curl write permission failure

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -115,7 +115,7 @@ fi
 
 if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
   log_params "Downloading Custom Planet File from Controller URL:" "$ZT_PLANET_URL_FILE"
-  tmpfile=$(mktemp)
+  tmpfile=$(sudo mktemp)
   attempt=1
   max_attempts=4
   success=false
@@ -134,7 +134,6 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
   # (some Docker DNS resolvers only return an AAAA record, and -4 alone does
   # not reliably prevent curl from taking that IPv6 path)
   zt_planet_ipv4=$(getent ahostsv4 "$zt_planet_host" 2>/dev/null | head -1 | awk '{print $1}')
-  log_params "DEBUG - resolved IPv4:" "[$zt_planet_ipv4]"
 
   if [ -n "$zt_planet_ipv4" ]; then
     resolve_opts="--resolve ${zt_planet_host}:${zt_planet_port}:${zt_planet_ipv4}"
@@ -144,18 +143,7 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
   fi
 
   while [ "$attempt" -le "$max_attempts" ]; do
-    # DEBUG - comparison run without sudo, to isolate whether sudo itself is
-    # the boot-time culprit. Output/exit code only, not used for success logic.
-    nosudo_tmpfile=$(mktemp)
-    curl -L -f $resolve_opts --max-time 30 "$ZT_PLANET_URL_FILE" -o "$nosudo_tmpfile" 2>&1
-    curl_nosudo_exit=$?
-    log_params "DEBUG - non-sudo curl exit code:" "$curl_nosudo_exit"
-    rm -f -- "$nosudo_tmpfile"
-
-    sudo curl -L -f $resolve_opts --max-time 30 "$ZT_PLANET_URL_FILE" -o "$tmpfile" 2>&1
-    curl_exit=$?
-    log_params "DEBUG - curl exit code:" "$curl_exit"
-    if [ "$curl_exit" -eq 0 ] && [ -s "$tmpfile" ]; then
+    if sudo curl -sL -f $resolve_opts --max-time 30 "$ZT_PLANET_URL_FILE" -o "$tmpfile" && [ -s "$tmpfile" ]; then
       success=true
       break
     fi


### PR DESCRIPTION
## Summary
- Fix the actual root cause of the intermittent planet file download failures: `tmpfile=$(mktemp)` created the temp file as the unprivileged container user, then `sudo curl -o "$tmpfile"` (running as root) failed to write into it with `Permission denied` on hosts where the container's root has restricted capabilities (no `CAP_DAC_OVERRIDE`). This was previously masked by `-s` silencing curl's error output and misdiagnosed as an IPv6/DNS issue. Switching to `tmpfile=$(sudo mktemp)` makes the file root-owned from creation, matching the pattern already used elsewhere in this script (`mkztfile()`).
- Remove the temporary DEBUG logging (resolved IPv4, curl exit codes) and the no-sudo comparison block used to diagnose the issue, now that the root cause is confirmed and fixed.

## Test plan
- [x] Verify CI checks pass on this PR
- [x] Confirm planet file download succeeds on a host with restricted container capabilities, where it previously failed every attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)