### PR TITLE
fix: make root-owned planet tmpfile readable for unprivileged sanity check

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -152,6 +152,9 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
     sleep 20
   done
   if [ "$success" = "true" ]; then
+    # tmpfile is root-owned (created via sudo mktemp); make it readable so the
+    # unprivileged shell's redirect below can open it for the sanity check
+    sudo chmod 0644 "$tmpfile"
     # Basic sanity check: a valid ZeroTier planet file should be at least a few hundred bytes
     # (real planet files are typically 100+ bytes; reject anything suspiciously small,
     # which usually indicates an HTML error page or empty/truncated response)


### PR DESCRIPTION
## Summary
- Follow-up to the previous `sudo mktemp` fix: that made the planet-file tmpfile root-owned, but the sanity check `filesize=$(wc -c < "$tmpfile")` runs as the unprivileged shell user, and shell input redirection opens the file *before* any `sudo` is applied to the command. So the download itself now succeeds, but the size check fails with `Permission denied`, breaking the "keep existing file" path.
- Fix: `sudo chmod 0644 "$tmpfile"` right after a successful download, before the unprivileged read, so the redirect can open it.

## Test plan
- [x] Verify CI checks pass on this PR
- [x] Confirm the planet file downloads and installs successfully end-to-end on the host that previously hit `can't open /tmp/tmp.XXXXXX: Permission denied`

🤖 Generated with [Claude Code](https://claude.com/claude-code)