### PR TITLE
fix: chown planet file to zerotier user for ownership consistency

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -162,6 +162,7 @@ if [ "x$ZT_PLANET_URL_FILE" != "x" ]; then
     if [ "$filesize" -ge 100 ]; then
       sudo cp "$tmpfile" /var/lib/zerotier-one/planet
       sudo chmod 0644 /var/lib/zerotier-one/planet
+      sudo chown zerotier:zerotier /var/lib/zerotier-one/planet 2>/dev/null || true
       log_params "Planet file updated successfully, size:" "$filesize bytes"
     else
       log_params "WARNING: Downloaded planet file looks invalid (too small), keeping existing file. Size:" "$filesize bytes"


### PR DESCRIPTION
## Summary
- After installing the downloaded planet file, `chown` it to `zerotier:zerotier` so it matches the ownership of every other file in `/var/lib/zerotier-one`, instead of being left `root:root` from the `sudo cp`/`sudo chmod` install step. This is cosmetic only — `chmod 0644` already grants the daemon read access regardless of owner.
- Made non-fatal (`2>/dev/null || true`) since some hardened hosts may not grant the container's root `CAP_CHOWN`, mirroring the `CAP_DAC_OVERRIDE` restriction uncovered earlier in this same investigation — a failure here should never break the download/install flow.

## Test plan
- [x] Verify CI checks pass on this PR
- [x] Confirm the installed planet file is owned by `zerotier:zerotier` (or silently stays as-is on hosts without `CAP_CHOWN`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)