### PR TITLE
build(deps): bump docker/scout-action from 1.23.1 to 1.24.0

### DIFF
--- a/.github/workflows/docker-scout.yml
+++ b/.github/workflows/docker-scout.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Docker Scout
         id: docker-scout
         if: ${{ github.event_name == 'pull_request' }}
-        uses: docker/scout-action@2688993af7bafd6ba8c6a74ec652442be91dd82b # v1.23.1
+        uses: docker/scout-action@7c6b6c3f7844478ace1ffd4e7aef649053d1f87d # v1.24.0
         with:
           command: cves,recommendations,compare
           image: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
## Summary
- Bumps `docker/scout-action` from 1.23.1 to 1.24.0 in `.github/workflows/docker-scout.yml` (dependabot, already merged to `dev`)

## Test plan
- [ ] Verify CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)